### PR TITLE
CI: Add simple jobs to test / lint / format both packages

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -1,0 +1,103 @@
+name: Setup environment
+
+inputs:
+  cargo-cache-key:
+    description: The key to cache cargo dependencies. Skips cargo caching if not provided.
+    required: false
+  cargo-cache-fallback-key:
+    description: The fallback key to use when caching cargo dependencies. Default to not using a fallback key.
+    required: false
+  cargo-cache-local-key:
+    description: The key to cache local cargo dependencies. Skips local cargo caching if not provided.
+    required: false
+  clippy:
+    description: Install Clippy if `true`. Defaults to `false`.
+    required: false
+  rustfmt:
+    description: Install Rustfmt if `true`. Defaults to `false`.
+    required: false
+  js:
+    description: Install pnpm and node if `true`. Defaults to `false`.
+    required: false
+  rust:
+    description: Install Rust if `true`. Defaults to `false`.
+    required: false
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Setup pnpm
+      if: ${{ inputs.js == 'true' }}
+      uses: pnpm/action-setup@v3
+      with:
+        package_json_file: 'js/package.json'
+
+    - name: Setup Node.js
+      if: ${{ inputs.js == 'true' }}
+      uses: actions/setup-node@v4
+      with:
+        node-version: 20
+        cache: 'pnpm'
+        cache-dependency-path: 'js/pnpm-lock.yaml'
+
+    - name: Install Rustfmt
+      if: ${{ inputs.rustfmt == 'true' }}
+      uses: dtolnay/rust-toolchain@master
+      with:
+        toolchain: "1.78.0"
+        components: rustfmt
+
+    - name: Install Clippy
+      if: ${{ inputs.clippy == 'true' }}
+      uses: dtolnay/rust-toolchain@master
+      with:
+        toolchain: "1.78.0"
+        components: clippy
+
+    - name: Install Rust
+      if: ${{ inputs.rust == 'true' }}
+      uses: dtolnay/rust-toolchain@master
+      with:
+        toolchain: "1.78.0"
+
+    - name: Cache Cargo Dependencies
+      if: ${{ inputs.cargo-cache-key && !inputs.cargo-cache-fallback-key }}
+      uses: actions/cache@v4
+      with:
+        path: |
+          ~/.cargo/bin/
+          ~/.cargo/registry/index/
+          ~/.cargo/registry/cache/
+          ~/.cargo/git/db/
+          target/
+        key: ${{ runner.os }}-${{ inputs.cargo-cache-key }}-${{ hashFiles('**/Cargo.lock') }}
+        restore-keys: ${{ runner.os }}-${{ inputs.cargo-cache-key }}
+
+    - name: Cache Cargo Dependencies With Fallback
+      if: ${{ inputs.cargo-cache-key && inputs.cargo-cache-fallback-key }}
+      uses: actions/cache@v4
+      with:
+        path: |
+          ~/.cargo/bin/
+          ~/.cargo/registry/index/
+          ~/.cargo/registry/cache/
+          ~/.cargo/git/db/
+          target/
+        key: ${{ runner.os }}-${{ inputs.cargo-cache-key }}-${{ hashFiles('**/Cargo.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-${{ inputs.cargo-cache-key }}
+          ${{ runner.os }}-${{ inputs.cargo-cache-fallback-key }}-${{ hashFiles('**/Cargo.lock') }}
+          ${{ runner.os }}-${{ inputs.cargo-cache-fallback-key }}
+
+    - name: Cache Local Cargo Dependencies
+      if: ${{ inputs.cargo-cache-local-key }}
+      uses: actions/cache@v4
+      with:
+        path: |
+          .cargo/bin/
+          .cargo/registry/index/
+          .cargo/registry/cache/
+          .cargo/git/db/
+        key: ${{ runner.os }}-${{ inputs.cargo-cache-local-key }}-${{ hashFiles('**/Cargo.lock') }}
+        restore-keys: ${{ runner.os }}-${{ inputs.cargo-cache-local-key }}
+

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,90 @@
+name: Main
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  format_and_lint_js:
+    name: Format & Lint JS
+    runs-on: ubuntu-latest
+    steps:
+      - name: Git Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Environment
+        uses: ./.github/actions/setup
+        with:
+          js: true
+
+      - name: Install Dependencies
+        run: cd js && pnpm install --frozen-lockfile
+
+      - name: Format
+        run: cd js && pnpm format
+
+      - name: Lint
+        run: cd js && pnpm lint
+
+  test_js:
+    name: Test JS
+    runs-on: ubuntu-latest
+    needs: format_and_lint_js
+    steps:
+      - name: Git Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Environment
+        uses: ./.github/actions/setup
+        with:
+          js: true
+
+      - name: Install Dependencies
+        run: cd js && pnpm install --frozen-lockfile
+
+      - name: Build code
+        run: cd js && pnpm build
+
+      - name: Run tests
+        run: cd js && pnpm test
+
+  format_and_lint_rust:
+    name: Format & Lint Rust
+    runs-on: ubuntu-latest
+    steps:
+      - name: Git Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Environment
+        uses: ./.github/actions/setup
+        with:
+          clippy: true
+          rustfmt: true
+          cargo-cache-key: cargo-lint-tests
+          cargo-cache-fallback-key: cargo-lint
+
+      - name: Format Rust
+        run: cd rust && cargo fmt --check
+
+      - name: Lint Rust
+        run: cd rust && cargo clippy
+
+  test_rust:
+    name: Test Rust
+    runs-on: ubuntu-latest
+    needs: format_and_lint_rust
+    steps:
+      - name: Git Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Environment
+        uses: ./.github/actions/setup
+        with:
+          rust: true
+          cargo-cache-key: cargo-rust-tests
+          cargo-cache-fallback-key: cargo-rust
+
+      - name: Run tests
+        run: cd rust && cargo test

--- a/js/package.json
+++ b/js/package.json
@@ -10,6 +10,7 @@
   "keywords": [],
   "author": "",
   "license": "Apache-2.0",
+  "packageManager": "pnpm@9.1.0",
   "exports": {
     ".": {
       "types": "./dist/types/index.d.ts",

--- a/rust/rust-toolchain.toml
+++ b/rust/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "1.78.0"
+


### PR DESCRIPTION
#### Problem

The rust and JS packages aren't being tested with CI.

#### Summary of changes

Add some simple CI jobs to test / lint / format the rust and JS packages. Note that there are no tests currently in the Rust side, but if we decide to add any, it'll be good to have the job ready.