### PR TITLE
fix: fix handling of `null` stake when parsing account info

### DIFF
--- a/web3js-1.0/src/rpc.ts
+++ b/web3js-1.0/src/rpc.ts
@@ -33,12 +33,16 @@ export async function getStakeActivation(
     })(),
   ]);
 
-  const { effective, activating, deactivating } =
+  const { effective, activating, deactivating } = stakeAccount.stake ?
     getStakeActivatingAndDeactivating(
       stakeAccount.stake.delegation,
       BigInt(epochInfo.epoch),
       stakeHistory
-    );
+    ) : {
+      effective: BigInt(0),
+      activating: BigInt(0),
+      deactivating: BigInt(0),
+    };
 
   let status;
   if (deactivating > 0) {

--- a/web3js-1.0/src/stake.ts
+++ b/web3js-1.0/src/stake.ts
@@ -31,7 +31,7 @@ export type StakeAccount = {
   stake: {
     delegation: Delegation,
     creditsObserved: bigint
-  }
+  } | null
 }
 
 export const getStakeHistory = function (parsedData: RpcResponseAndContext<AccountInfo<ParsedAccountData | Buffer> | null>): StakeHistoryEntry[] {
@@ -77,7 +77,7 @@ export const getStakeAccount = function (parsedData: RpcResponseAndContext<Accou
         custodian: parsedData.value.data.parsed.info.meta.lockup.custodian
       }
     },
-    stake: {
+    stake: parsedData.value.data.parsed.info.stake ? {
       delegation: {
         voterPubkey: parsedData.value.data.parsed.info.stake.delegation.voterPubkey,
         stake: BigInt(parsedData.value.data.parsed.info.stake.delegation.stake),
@@ -85,6 +85,6 @@ export const getStakeAccount = function (parsedData: RpcResponseAndContext<Accou
         deactivationEpoch: BigInt(parsedData.value.data.parsed.info.stake.delegation.deactivationEpoch),
       },
       creditsObserved: BigInt(parsedData.value.data.parsed.info.stake.creditsObserved)
-    }
+    } : null
   }
 }


### PR DESCRIPTION
We noticed that parsed account info may contain `null` stake in which case the lib crashes. This PR attempts to fix that

related to https://github.com/solana-developers/solana-rpc-get-stake-activation/issues/7