### PR TITLE
js-v1: Add runnable example

### DIFF
--- a/js-v1/examples/README.md
+++ b/js-v1/examples/README.md
@@ -1,0 +1,24 @@
+# Examples
+
+There is an example using `getStakeActivation` against a live testnet stake
+account.
+
+## Getting started
+
+* Install the dependencies
+
+```console
+pnpm install
+```
+
+* Build the example
+
+```console
+pnpm build
+```
+
+* Run it
+
+```console
+node dist/src/index.js
+```

--- a/js-v1/examples/example.ts
+++ b/js-v1/examples/example.ts
@@ -1,8 +1,0 @@
-import { getStakeActivation } from 'solana-rpc-get-stake-activation';
-import { PublicKey } from "@solana/web3.js";
-import { Connection } from '@solana/web3.js';
-
-const connection = new Connection('https://api.testnet.solana.com');
-let stake = new PublicKey('25R5p1Qoe4BWW4ru7MQSNxxAzdiPN7zAunpCuF8q5iTz');
-let status = await getStakeActivation(connection, stake);
-console.log(status);

--- a/js-v1/examples/package.json
+++ b/js-v1/examples/package.json
@@ -1,0 +1,57 @@
+{
+  "name": "@anza-xyz/solana-rpc-get-stake-activation-example",
+  "version": "1.0.0",
+  "description": "Example using getStakeActivation",
+  "sideEffects": false,
+  "module": "./dist/src/index.mjs",
+  "main": "./dist/src/index.js",
+  "types": "./dist/types/index.d.ts",
+  "type": "commonjs",
+  "keywords": [
+    "blockchain",
+    "solana",
+    "rpc",
+    "web3"
+  ],
+  "author": "Anza Maintainers <maintainers@anza.xyz>",
+  "license": "Apache-2.0",
+  "packageManager": "pnpm@9.1.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/anza-xyz/solana-rpc-client-extensions"
+  },
+  "bugs": {
+    "url": "https://github.com/anza-xyz/solana-rpc-client-extensions/issues"
+  },
+  "publishConfig": {
+    "access": "private"
+  },
+  "exports": {
+    ".": {
+      "types": "./dist/types/index.d.ts",
+      "import": "./dist/src/index.mjs",
+      "require": "./dist/src/index.js"
+    }
+  },
+  "files": [
+    "./dist/src",
+    "./dist/types"
+  ],
+  "scripts": {
+    "build": "rimraf dist && tsup && tsc",
+    "lint": "eslint --ext js,ts,tsx src",
+    "lint:fix": "eslint --fix --ext js,ts,tsx src",
+    "format": "prettier --check src",
+    "format:fix": "prettier --write src",
+    "prepublishOnly": "pnpm build"
+  },
+  "dependencies": {
+    "@anza-xyz/solana-rpc-get-stake-activation": "1.0.1",
+    "@solana/web3.js": "1.95"
+  },
+  "devDependencies": {
+    "rimraf": "^5.0.5",
+    "tsup": "^8.1.2",
+    "typescript": "^5.5.3"
+  }
+}

--- a/js-v1/examples/src/index.ts
+++ b/js-v1/examples/src/index.ts
@@ -1,0 +1,10 @@
+import { getStakeActivation } from '@anza-xyz/solana-rpc-get-stake-activation';
+import { PublicKey } from '@solana/web3.js';
+import { Connection } from '@solana/web3.js';
+
+(async () => {
+  const connection = new Connection('https://api.testnet.solana.com');
+  let stake = new PublicKey('25R5p1Qoe4BWW4ru7MQSNxxAzdiPN7zAunpCuF8q5iTz');
+  let status = await getStakeActivation(connection, stake);
+  console.log(status);
+})();


### PR DESCRIPTION
#### Problem

As mentioned at #12, it's unclear how to run the example.

#### Summary of changes

Add a corresponding package.json, making it possible to simply install dependencies, build, and run the example.