### PR TITLE
js: Add fuller example with package.json

### DIFF
--- a/js/examples/README.md
+++ b/js/examples/README.md
@@ -1,0 +1,24 @@
+# Examples
+
+There is an example using `getStakeActivation` against a live testnet stake
+account.
+
+## Getting started
+
+* Install the dependencies
+
+```console
+pnpm install
+```
+
+* Build the example
+
+```console
+pnpm build
+```
+
+* Run it
+
+```console
+node dist/src/index.js
+```

--- a/js/examples/package.json
+++ b/js/examples/package.json
@@ -1,0 +1,58 @@
+{
+  "name": "@anza-xyz/solana-rpc-get-stake-activation-example",
+  "version": "2.0.0",
+  "description": "Example using getStakeActivation",
+  "sideEffects": false,
+  "module": "./dist/src/index.mjs",
+  "main": "./dist/src/index.js",
+  "types": "./dist/types/index.d.ts",
+  "type": "commonjs",
+  "keywords": [
+    "blockchain",
+    "solana",
+    "rpc",
+    "web3"
+  ],
+  "author": "Anza Maintainers <maintainers@anza.xyz>",
+  "license": "Apache-2.0",
+  "packageManager": "pnpm@9.1.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/anza-xyz/solana-rpc-client-extensions"
+  },
+  "bugs": {
+    "url": "https://github.com/anza-xyz/solana-rpc-client-extensions/issues"
+  },
+  "publishConfig": {
+    "access": "private"
+  },
+  "exports": {
+    ".": {
+      "types": "./dist/types/index.d.ts",
+      "import": "./dist/src/index.mjs",
+      "require": "./dist/src/index.js"
+    }
+  },
+  "files": [
+    "./dist/src",
+    "./dist/types"
+  ],
+  "scripts": {
+    "build": "rimraf dist && tsup && tsc",
+    "lint": "eslint --ext js,ts,tsx src",
+    "lint:fix": "eslint --fix --ext js,ts,tsx src",
+    "format": "prettier --check src",
+    "format:fix": "prettier --write src",
+    "prepublishOnly": "pnpm build"
+  },
+  "dependencies": {
+    "@anza-xyz/solana-rpc-get-stake-activation": "2.0.0",
+    "@solana/addresses": "2.0.0-rc.0",
+    "@solana/rpc": "2.0.0-rc.0"
+  },
+  "devDependencies": {
+    "rimraf": "^5.0.5",
+    "tsup": "^8.1.2",
+    "typescript": "^5.5.3"
+  }
+}

--- a/js/examples/rpc.ts
+++ b/js/examples/rpc.ts
@@ -1,8 +1,0 @@
-import { Address } from '@solana/addresses';
-import { createSolanaRpc } from '@solana/rpc';
-import { getStakeActivation } from 'solana-rpc-get-stake-activation';
-
-const rpc = createSolanaRpc('https://api.testnet.solana.com');
-let stake = '25R5p1Qoe4BWW4ru7MQSNxxAzdiPN7zAunpCuF8q5iTz';
-let status = await getStakeActivation(rpc, stake as Address);
-console.log(status);

--- a/js/examples/src/index.ts
+++ b/js/examples/src/index.ts
@@ -1,0 +1,10 @@
+import { getStakeActivation } from '@anza-xyz/solana-rpc-get-stake-activation';
+import { Address } from '@solana/addresses';
+import { createSolanaRpc } from '@solana/rpc';
+
+(async () => {
+  const rpc = createSolanaRpc('https://api.testnet.solana.com');
+  let stake = '25R5p1Qoe4BWW4ru7MQSNxxAzdiPN7zAunpCuF8q5iTz';
+  let status = await getStakeActivation(rpc, stake as Address);
+  console.log(status);
+})();


### PR DESCRIPTION
#### Problem

As mentioned at #12, it's unclear how to run the example.

#### Summary of changes

Add a corresponding package.json, making it possible to simply install dependencies, build it, and run.