### PR TITLE
fix: type check

### DIFF
--- a/js/src/delegation.ts
+++ b/js/src/delegation.ts
@@ -113,7 +113,7 @@ export function getStakeActivatingAndDeactivating(
       activating,
       deactivating: BigInt(0),
     };
-  } else if (targetEpoch === delegation.deactivationEpoch) {
+  } else if (targetEpoch === BigInt(delegation.deactivationEpoch)) {
     // can only deactivate what's activated
     return {
       effective,


### PR DESCRIPTION
Closes: https://github.com/anza-xyz/solana-rpc-client-extensions/issues/15

Fix wrong check.

Can't compare BigInt with String using `===`.