### PR TITLE
Don't use the concrete implementation of web3.js in the `getStakeActivation` package

### DIFF
--- a/js-v1/src/rpc.ts
+++ b/js-v1/src/rpc.ts
@@ -12,9 +12,9 @@ export async function getStakeActivation(
   connection: Connection,
   stakeAddress: PublicKey
 ): Promise<StakeActivation> {
-  const SYSVAR_STAKE_HISTORY_ADDRESS = new PublicKey(
-    'SysvarStakeHistory1111111111111111111111111'
-  );
+  const SYSVAR_STAKE_HISTORY_ADDRESS = {
+    toBase58: () => 'SysvarStakeHistory1111111111111111111111111',
+  } as unknown as PublicKey; // Prevents a concrete dependency on `PublicKey`
   const [epochInfo, { stakeAccount, stakeAccountLamports }, stakeHistory] =
     await Promise.all([
       connection.getEpochInfo(),


### PR DESCRIPTION
The only place that `@solana/web3.js` is used in this shim – in a non-type position – is here. We can make a mock of `PublicKey` here which breaks the last dependency on the actual implementation of `@solana/web3.js`. Now all that is used from that package are the types.